### PR TITLE
moving inner loop into getRowText function

### DIFF
--- a/lib/widgets/listtable.js
+++ b/lib/widgets/listtable.js
@@ -93,6 +93,50 @@ ListTable.prototype.type = 'list-table';
 
 ListTable.prototype._calculateMaxes = Table.prototype._calculateMaxes;
 
+ListTable.prototype.getRowText = function(row) {
+  var self = this
+    , align = this.__align
+    , text = ''
+
+  row.forEach(function(cell, i) {
+    var width = self._maxes[i];
+    var clen = self.strWidth(cell);
+
+    if (i !== 0) {
+      text += ' ';
+    }
+
+    while (clen < width) {
+      if (align === 'center') {
+        cell = ' ' + cell + ' ';
+        clen += 2;
+      } else if (align === 'left') {
+        cell = cell + ' ';
+        clen += 1;
+      } else if (align === 'right') {
+        cell = ' ' + cell;
+        clen += 1;
+      }
+    }
+
+    if (clen > width) {
+      if (align === 'center') {
+        cell = cell.substring(1);
+        clen--;
+      } else if (align === 'left') {
+        cell = cell.slice(0, -1);
+        clen--;
+      } else if (align === 'right') {
+        cell = cell.substring(1);
+        clen--;
+      }
+    }
+
+    text += cell;
+  });
+  return text
+};
+
 ListTable.prototype.setRows =
 ListTable.prototype.setData = function(rows) {
   var self = this
@@ -117,43 +161,8 @@ ListTable.prototype.setData = function(rows) {
 
   this.rows.forEach(function(row, i) {
     var isHeader = i === 0;
-    var text = '';
-    row.forEach(function(cell, i) {
-      var width = self._maxes[i];
-      var clen = self.strWidth(cell);
+    var text = self.getRowText(row)
 
-      if (i !== 0) {
-        text += ' ';
-      }
-
-      while (clen < width) {
-        if (align === 'center') {
-          cell = ' ' + cell + ' ';
-          clen += 2;
-        } else if (align === 'left') {
-          cell = cell + ' ';
-          clen += 1;
-        } else if (align === 'right') {
-          cell = ' ' + cell;
-          clen += 1;
-        }
-      }
-
-      if (clen > width) {
-        if (align === 'center') {
-          cell = cell.substring(1);
-          clen--;
-        } else if (align === 'left') {
-          cell = cell.slice(0, -1);
-          clen--;
-        } else if (align === 'right') {
-          cell = cell.substring(1);
-          clen--;
-        }
-      }
-
-      text += cell;
-    });
     if (isHeader) {
       self._header.setContent(text);
     } else {


### PR DESCRIPTION
Why?

- Better code organization by reducing the amount of indentation
- This function is useful in isolation when wanting to re-render a single existing item in the table, or a new item
  - My use case is [highlighting multiple selections](https://github.com/dctucker/octoterm/blob/b900fb79cd0423d56276df0407d1555142be3c42/AgendaView.js#L138) by tweaking the attributes (e.g. bold)
