### PR TITLE
adding true color support for tags, not yet working for all widgets

### DIFF
--- a/lib/program.js
+++ b/lib/program.js
@@ -2767,6 +2767,20 @@ Program.prototype._attr = function(param, val) {
     default:
       // 256-color fg and bg
       if (param[0] === '#') {
+        if( process.env.COLORTERM === 'truecolor' ){
+          m = param.substring(1).split(' ')
+          let r = parseInt(m[0].substring(0,2), 16)
+          let g = parseInt(m[0].substring(2,4), 16)
+          let b = parseInt(m[0].substring(4,6), 16)
+          color = r+';'+g+';'+b
+          if (m[1] === 'fg') {
+            return '\x1b[38;2;' + color + 'm';
+          }
+          if (m[1] === 'bg') {
+            return '\x1b[48;2;' + color + 'm';
+          }
+          return null
+        }
         param = param.replace(/#(?:[0-9a-f]{3}){1,2}/i, colors.match);
       }
 


### PR DESCRIPTION
Looks like there's demand for true color support based on https://github.com/chjj/blessed/issues/185 so I figured I'd try to introduce it.

Unfortunately, I haven't yet figured out how to make this work for all elements on the screen, in fact it only seems to work for tags so far. If someone else who knows could jump in and help me fill in the gaps in my knowledge, I'd appreciate it.